### PR TITLE
zephyr: Add module.yaml to integrate as Zephyr module

### DIFF
--- a/zephyr/module.yaml
+++ b/zephyr/module.yaml
@@ -1,0 +1,4 @@
+name: lzma
+build:
+  cmake: .
+  kconfig: Kconfig

--- a/zephyr/module.yaml
+++ b/zephyr/module.yaml
@@ -1,4 +1,4 @@
 name: lzma
 build:
-  cmake: .
-  kconfig: Kconfig
+  cmake: zephyr
+  kconfig: zephyr/Kconfig


### PR DESCRIPTION
- Add module.yaml to integrate as Zephyr module